### PR TITLE
feat(*): support arm64 building

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,16 @@
+FROM cargo.caicloud.xyz/arm64v8/golang:1.11
+
+WORKDIR /go/src/github.com/percona/mongodb_exporter
+
+COPY . .
+
+RUN make build
+
+FROM cargo.caicloud.xyz/arm64v8/busybox:latest
+
+COPY --from=0 /go/src/github.com/percona/mongodb_exporter/bin/mongodb_exporter /bin/mongodb_exporter
+
+EXPOSE 9216
+
+ENTRYPOINT [ "/bin/mongodb_exporter" ]
+

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,15 @@ export PMM_RELEASE_TIMESTAMP  = $(shell date '+%s')
 export PMM_RELEASE_FULLCOMMIT = $(APP_REVISION)
 export PMM_RELEASE_BRANCH     = $(TRAVIS_BRANCH)
 
+ARCH ?= amd64
+
+# Change Dockerfile name and registry project name for arm64
+ifeq ($(ARCH),arm64)
+DOCKERFILE := Dockerfile.arm64
+else
+DOCKERFILE := Dockerfile
+endif
+
 all: clean format build test
 
 style:
@@ -89,7 +98,7 @@ community-release: $(GOPATH)/bin/goreleaser
 
 docker:
 	@echo ">> building docker image"
-	@docker build -t "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
+	@docker build -t "$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" -f $(DOCKERFILE) .
 
 $(GOPATH)/bin/dep:
 	curl -s https://raw.githubusercontent.com/golang/dep/v0.5.0/install.sh | sh


### PR DESCRIPTION
构建命令

```bash
make docker DOCKER_IMAGE_TAG=v0.0.1 ARCH=arm64
```

构建镜像

```
cargo.caicloud.xyz/arm64v8/mongodb-exporter:v0.0.1
```

arm64 运行测试
![image](https://user-images.githubusercontent.com/25719123/75859389-df8b9a80-5e34-11ea-8452-2864340b6b54.png)

/cc @bbbmj @supereagle 